### PR TITLE
Create a custom 404 error page

### DIFF
--- a/pages/error.vue
+++ b/pages/error.vue
@@ -1,0 +1,17 @@
+<template>
+    <div class="flex flex-col items-center justify-center h-screen bg-gray-100">
+        <!-- Main heading for the 404 error -->
+        <h1 class="text-6xl font-bold text-gray-800">404 Not Found</h1>
+        <p class="mt-4 text-lg text-gray-600">Sorry, the page you are looking for does not exist.</p>
+        <nuxt-link to="/" class="mt-6 text-blue-500 hover:underline">Go back to Home</nuxt-link>
+    </div>
+</template>
+
+<script setup>
+// No additional logic is needed for a simple 404 error page.
+// The setup is handled by Nuxt.js automatically.
+</script>
+
+<style scoped>
+/* Additional styling can be added here if desired. */
+</style>


### PR DESCRIPTION
This pull request introduces a custom 404 error page in the `pages` directory to enhance user experience when accessing non-existent pages. The page provides a clear message indicating the error and includes a link for users to return to the home page. This implementation adheres to Nuxt.js best practices for error handling.
